### PR TITLE
Handling long filenames of mesos-slave's sandbox dirs

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,8 @@ func main() {
 
 	loggers := make(map[string]Logger)
 	loggers["rsyslog"] = &Rsyslog{
-		ConfigLocation: rsyslogConfigurationDir,
+		WorkDir: workDir,
+		SyslogConfigLocation: rsyslogConfigurationDir,
 		RestartCommand: rsyslogRestartCommand,
 	}
 	logManager = LogManager{
@@ -65,6 +66,7 @@ func init() {
 	flag.IntVar(&mesosSlavePort, "slave-port", 5051, "Mesos slave port")
 	flag.DurationVar(&appCheckInterval, "app-check-interval", 30*time.Second, "Frequency at which we check for new tasks")
 	flag.DurationVar(&taskMaxHeartBeatInterval, "task-max-heart-beat-interval", 30*time.Minute, "Max heartbeat interval after which the task is considered dead and logger is removed")
+	flag.StringVar(&workDir, "work-dir", "/tmp/", "Location on the Filesystem where we create symlinks to app location base dir. This is needed to ensure the file paths don't become too long and crashes rsyslog")
 	flag.StringVar(&rsyslogConfigurationDir, "rsyslog-configuration-dir", "/etc/rsyslog.d", "Location on the Filesystem where the rsyslog configurations needs to be written")
 	flag.StringVar(&rsyslogRestartCommand, "rsyslog-restart-cmd", "service rsyslog restart", "Restart command for rsyslog backend")
 }

--- a/task-manager.go
+++ b/task-manager.go
@@ -21,6 +21,7 @@ type TaskInfo struct {
 	Hostname string
 	CWD      string // Current working directory of the task in the slave
 	FileName string // Actual file name to that we need monitor for logs
+	WorkDir	 string // WorkDir location of marathon-logger where we setup Symlink
 }
 
 // CleanAppName cleans the app-name string for `/` characters
@@ -105,7 +106,7 @@ func (t *TaskManager) run() {
 								Labels:   task.Labels,
 								TaskID:   task.TaskID,
 								CWD:      executor.Directory,
-								FileName: file,
+								FileName: file
 							}
 							// fmt.Printf("%v\n", taskInfo)
 							t.AddLogs <- taskInfo


### PR DESCRIPTION
rsyslog crashes if the filename that it has to monitor exceeds 200 chars. To work around that, we create a symlink to the task dir of mesos sandbox and add that path as the file to be watched in rsyslog. This should safely keep it under the 200 char file path limit
