### PR TITLE
Symlink for filenames

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: f6fb8aeb274a3a8fc0a91354a0dcbb6301e877a15c97dd3280378bbbc72420b9
-updated: 2016-09-15T23:48:06.799367028+05:30
+updated: 2016-08-08T16:53:26.509201112+05:30
 imports:
 - name: github.com/ashwanthkumar/golang-utils
   version: 6362d7ff76b62be7ac4ef53aad5812791b390974
@@ -34,7 +34,7 @@ imports:
   - publicsuffix
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: f6fb8aeb274a3a8fc0a91354a0dcbb6301e877a15c97dd3280378bbbc72420b9
-updated: 2016-08-08T16:53:26.509201112+05:30
+updated: 2016-09-15T23:48:06.799367028+05:30
 imports:
 - name: github.com/ashwanthkumar/golang-utils
   version: 6362d7ff76b62be7ac4ef53aad5812791b390974
@@ -34,7 +34,7 @@ imports:
   - publicsuffix
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 2df174808ee097f90d259e432cc04442cf60be21
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ var marathonURI string
 var mesosSlavePort int
 var appCheckInterval time.Duration
 var taskMaxHeartBeatInterval time.Duration
+
+var workDir string
 var rsyslogConfigurationDir string
 var rsyslogRestartCommand string
 
@@ -46,7 +48,8 @@ func main() {
 
 	loggers := make(map[string]Logger)
 	loggers["rsyslog"] = &Rsyslog{
-		ConfigLocation: rsyslogConfigurationDir,
+		WorkDir: workDir,
+		SyslogConfigLocation: rsyslogConfigurationDir,
 		RestartCommand: rsyslogRestartCommand,
 	}
 	logManager = LogManager{
@@ -65,6 +68,7 @@ func init() {
 	flag.IntVar(&mesosSlavePort, "slave-port", 5051, "Mesos slave port")
 	flag.DurationVar(&appCheckInterval, "app-check-interval", 30*time.Second, "Frequency at which we check for new tasks")
 	flag.DurationVar(&taskMaxHeartBeatInterval, "task-max-heart-beat-interval", 30*time.Minute, "Max heartbeat interval after which the task is considered dead and logger is removed")
+	flag.StringVar(&workDir, "work-dir", "/tmp/", "Location on the Filesystem where we create symlinks to app location base dir. This is needed to ensure the file paths don't become too long and crashes rsyslog")
 	flag.StringVar(&rsyslogConfigurationDir, "rsyslog-configuration-dir", "/etc/rsyslog.d", "Location on the Filesystem where the rsyslog configurations needs to be written")
 	flag.StringVar(&rsyslogRestartCommand, "rsyslog-restart-cmd", "service rsyslog restart", "Restart command for rsyslog backend")
 }

--- a/rsyslog-logger_test.go
+++ b/rsyslog-logger_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderRsyslogTemplate(t *testing.T) {
+
+	hostname, err := os.Hostname()
+	var rsyslog = Rsyslog{
+		WorkDir: "/foo/bar",
+	}
+	label := map[string]string{
+		"logs.enabled": "true",
+	}
+	taskInfo := TaskInfo{
+		App:      "/test.aayush.http",
+		Hostname: hostname,
+		Labels:   label,
+		TaskID:   "abcdefghij",
+		CWD:      "/foo/bar",
+		FileName: "test_file_name.txt",
+	}
+
+	expected := `
+######################################
+# Created via marathon-logger,
+# PLEASE DON'T EDIT THIS FILE MANUALLY
+# Name - /test.aayush.http
+# File - test_file_name.txt
+######################################
+
+input(type="imfile"
+	File="/foo/bar/abcdefghij/test_file_name.txt"
+	Tag="test.aayush.http	abcdefghij"
+	Severity="info")
+`
+	template, err := rsyslog.render(taskInfo)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, template)
+}

--- a/task-info_test.go
+++ b/task-info_test.go
@@ -44,9 +44,9 @@ func TestRenderRsyslogTemplate(t *testing.T) {
 ######################################
 
 input(type="imfile"
-			File="/foo/bar/test_file_name.txt"
-			Tag="test.aayush.http	abcdefghij"
-      Severity="info")
+		File="/foo/bar/abcdefghij/test_file_name.txt"
+		Tag="test.aayush.http	abcdefghij"
+    Severity="info")
 `
 	template, err := rsyslog.render(taskInfo)
 	assert.NoError(t, err)

--- a/task-info_test.go
+++ b/task-info_test.go
@@ -20,7 +20,9 @@ func TestCleanAppName(t *testing.T) {
 func TestRenderRsyslogTemplate(t *testing.T) {
 
 	hostname, err := os.Hostname()
-	var rsyslog Rsyslog
+	var rsyslog Rsyslog = Rsyslog {
+		WorkDir: "/foo/bar",
+	}
 	label := map[string]string{
 		"logs.enabled": "true",
 	}
@@ -41,12 +43,9 @@ func TestRenderRsyslogTemplate(t *testing.T) {
 # File - test_file_name.txt
 ######################################
 
-module(load="imfile")
-
 input(type="imfile"
 			File="/foo/bar/test_file_name.txt"
 			Tag="test.aayush.http	abcdefghij"
-			statefile="abcdefghij"
       Severity="info")
 `
 	template, err := rsyslog.render(taskInfo)

--- a/task-info_test.go
+++ b/task-info_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,40 +14,4 @@ func TestCleanAppName(t *testing.T) {
 	assert.Equal(t, testCaseTwo.CleanAppName(), "test.aayush.http", "They should be equal")
 	testCaseThree.App = "/test.aayush.http/"
 	assert.Equal(t, testCaseThree.CleanAppName(), "test.aayush.http.", "They should be equal")
-}
-
-func TestRenderRsyslogTemplate(t *testing.T) {
-
-	hostname, err := os.Hostname()
-	var rsyslog Rsyslog = Rsyslog {
-		WorkDir: "/foo/bar",
-	}
-	label := map[string]string{
-		"logs.enabled": "true",
-	}
-	taskInfo := TaskInfo{
-		App:      "/test.aayush.http",
-		Hostname: hostname,
-		Labels:   label,
-		TaskID:   "abcdefghij",
-		CWD:      "/foo/bar",
-		FileName: "test_file_name.txt",
-	}
-
-	expected := `
-######################################
-# Created via marathon-logger,
-# PLEASE DON'T EDIT THIS FILE MANUALLY
-# Name - /test.aayush.http
-# File - test_file_name.txt
-######################################
-
-input(type="imfile"
-		File="/foo/bar/abcdefghij/test_file_name.txt"
-		Tag="test.aayush.http	abcdefghij"
-    Severity="info")
-`
-	template, err := rsyslog.render(taskInfo)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, template)
 }

--- a/task-manager.go
+++ b/task-manager.go
@@ -21,7 +21,7 @@ type TaskInfo struct {
 	Hostname string
 	CWD      string // Current working directory of the task in the slave
 	FileName string // Actual file name to that we need monitor for logs
-	WorkDir	 string // WorkDir location of marathon-logger where we setup Symlink
+	WorkDir  string // WorkDir location of marathon-logger where we setup Symlink
 }
 
 // CleanAppName cleans the app-name string for `/` characters
@@ -86,44 +86,42 @@ func (t *TaskManager) run() {
 				}
 			}
 		case task := <-t.InputTasksChannel:
-	//		if task.Hostname == hostname {
-				// println("Got task for addition.. do what needs to be done")
-				// fmt.Printf("%v\n", task)
-				t.TasksMutex.Lock()
-				_, present := t.KnownTasks[task.TaskID]
-				if !present {
-					log.Printf("TaskID %s is not monitored, sending it to LogManager", task.TaskID)
-					slaveState, _ := t.Client.SlaveState(fmt.Sprintf("http://%s:%d/state.json", hostname, t.SlavePort))
-					// fmt.Printf("%v\n", slaveState)
-					executor := slaveState.FindExecutor(task.TaskID)
-					if executor != nil {
-						logFiles := strings.Split(maps.GetString(task.Labels, LogFilesToMonitor, "stdout"), ",")
-						t.KnownTasks[task.TaskID] = time.Now()
-						for _, file := range logFiles {
-							taskInfo := TaskInfo{
-								App:      task.App,
-								Hostname: task.Hostname,
-								Labels:   task.Labels,
-								TaskID:   task.TaskID,
-								CWD:      executor.Directory,
-								FileName: file,
-							}
-							// fmt.Printf("%v\n", taskInfo)
-							t.AddLogs <- taskInfo
+			// TODO hostname check is an optimisation to avoid HTTP calls to mesos slave
+			// currently in our setup hostnames a little messed up, so disabling this chck for now
+			// if task.Hostname == hostname {
+			// println("Got task for addition.. do what needs to be done")
+			// fmt.Printf("%v\n", task)
+			t.TasksMutex.Lock()
+			_, present := t.KnownTasks[task.TaskID]
+			if !present {
+				log.Printf("TaskID %s is not monitored, sending it to LogManager", task.TaskID)
+				slaveState, _ := t.Client.SlaveState(fmt.Sprintf("http://%s:%d/state.json", hostname, t.SlavePort))
+				// fmt.Printf("%v\n", slaveState)
+				executor := slaveState.FindExecutor(task.TaskID)
+				if executor != nil {
+					logFiles := strings.Split(maps.GetString(task.Labels, LogFilesToMonitor, "stdout"), ",")
+					t.KnownTasks[task.TaskID] = time.Now()
+					for _, file := range logFiles {
+						taskInfo := TaskInfo{
+							App:      task.App,
+							Hostname: task.Hostname,
+							Labels:   task.Labels,
+							TaskID:   task.TaskID,
+							CWD:      executor.Directory,
+							FileName: file,
 						}
-					} else {
-						log.Printf("[WARN] Couldn't find the executor that spun up the task %s", task.TaskID)
+						// fmt.Printf("%v\n", taskInfo)
+						t.AddLogs <- taskInfo
 					}
 				} else {
-					// Already present - update the clock
-					t.KnownTasks[task.TaskID] = time.Now()
+					log.Printf("[WARN] Couldn't find the executor that spun up the task %s", task.TaskID)
 				}
-				t.TasksMutex.Unlock()
-		//	}
-			// 1. Check if the task is running on our machine
-			// 2. Check if we already know the task
-			// 3. If yes, just update the KnownTasks map
-			// 4. Else, construct a TaskInfo object and send it to Log Manager and update the KnownTasks map
+			} else {
+				// Already present - update the clock
+				t.KnownTasks[task.TaskID] = time.Now()
+			}
+			t.TasksMutex.Unlock()
+			// }
 		case <-t.stopChannel:
 			running = false
 		}

--- a/task-manager.go
+++ b/task-manager.go
@@ -21,6 +21,7 @@ type TaskInfo struct {
 	Hostname string
 	CWD      string // Current working directory of the task in the slave
 	FileName string // Actual file name to that we need monitor for logs
+	WorkDir	 string // WorkDir location of marathon-logger where we setup Symlink
 }
 
 // CleanAppName cleans the app-name string for `/` characters
@@ -109,6 +110,31 @@ func (t *TaskManager) run() {
 							CWD:      executor.Directory,
 							FileName: file,
 						}
+			//if task.Hostname == hostname {
+				// println("Got task for addition.. do what needs to be done")
+				// fmt.Printf("%v\n", task)
+				t.TasksMutex.Lock()
+				_, present := t.KnownTasks[task.TaskID]
+				if !present {
+					log.Printf("TaskID %s is not monitored, sending it to LogManager", task.TaskID)
+					slaveState, _ := t.Client.SlaveState(fmt.Sprintf("http://%s:%d/state.json", hostname, t.SlavePort))
+					// fmt.Printf("%v\n", slaveState)
+					executor := slaveState.FindExecutor(task.TaskID)
+					if executor != nil {
+						logFiles := strings.Split(maps.GetString(task.Labels, LogFilesToMonitor, "stdout"), ",")
+						t.KnownTasks[task.TaskID] = time.Now()
+						for _, file := range logFiles {
+							taskInfo := TaskInfo{
+								App:      task.App,
+								Hostname: task.Hostname,
+								Labels:   task.Labels,
+								TaskID:   task.TaskID,
+								CWD:      executor.Directory,
+								FileName: file,
+							}
+							// fmt.Printf("%v\n", taskInfo)
+							t.AddLogs <- taskInfo
+						}
 						// fmt.Printf("%v\n", taskInfo)
 						t.AddLogs <- taskInfo
 					}
@@ -121,6 +147,12 @@ func (t *TaskManager) run() {
 			}
 			t.TasksMutex.Unlock()
 			// }
+				t.TasksMutex.Unlock()
+			//}
+			// 1. Check if the task is running on our machine
+			// 2. Check if we already know the task
+			// 3. If yes, just update the KnownTasks map
+			// 4. Else, construct a TaskInfo object and send it to Log Manager and update the KnownTasks map
 		case <-t.stopChannel:
 			running = false
 		}

--- a/task-manager.go
+++ b/task-manager.go
@@ -86,31 +86,7 @@ func (t *TaskManager) run() {
 				}
 			}
 		case task := <-t.InputTasksChannel:
-			// TODO hostname check is an optimisation to avoid HTTP calls to mesos slave
-			// currently in our setup hostnames a little messed up, so disabling this chck for now
-			// if task.Hostname == hostname {
-			// println("Got task for addition.. do what needs to be done")
-			// fmt.Printf("%v\n", task)
-			t.TasksMutex.Lock()
-			_, present := t.KnownTasks[task.TaskID]
-			if !present {
-				log.Printf("TaskID %s is not monitored, sending it to LogManager", task.TaskID)
-				slaveState, _ := t.Client.SlaveState(fmt.Sprintf("http://%s:%d/state.json", hostname, t.SlavePort))
-				// fmt.Printf("%v\n", slaveState)
-				executor := slaveState.FindExecutor(task.TaskID)
-				if executor != nil {
-					logFiles := strings.Split(maps.GetString(task.Labels, LogFilesToMonitor, "stdout"), ",")
-					t.KnownTasks[task.TaskID] = time.Now()
-					for _, file := range logFiles {
-						taskInfo := TaskInfo{
-							App:      task.App,
-							Hostname: task.Hostname,
-							Labels:   task.Labels,
-							TaskID:   task.TaskID,
-							CWD:      executor.Directory,
-							FileName: file,
-						}
-			//if task.Hostname == hostname {
+	//		if task.Hostname == hostname {
 				// println("Got task for addition.. do what needs to be done")
 				// fmt.Printf("%v\n", task)
 				t.TasksMutex.Lock()
@@ -135,20 +111,15 @@ func (t *TaskManager) run() {
 							// fmt.Printf("%v\n", taskInfo)
 							t.AddLogs <- taskInfo
 						}
-						// fmt.Printf("%v\n", taskInfo)
-						t.AddLogs <- taskInfo
+					} else {
+						log.Printf("[WARN] Couldn't find the executor that spun up the task %s", task.TaskID)
 					}
 				} else {
-					log.Printf("[WARN] Couldn't find the executor that spun up the task %s", task.TaskID)
+					// Already present - update the clock
+					t.KnownTasks[task.TaskID] = time.Now()
 				}
-			} else {
-				// Already present - update the clock
-				t.KnownTasks[task.TaskID] = time.Now()
-			}
-			t.TasksMutex.Unlock()
-			// }
 				t.TasksMutex.Unlock()
-			//}
+		//	}
 			// 1. Check if the task is running on our machine
 			// 2. Check if we already know the task
 			// 3. If yes, just update the KnownTasks map


### PR DESCRIPTION
This PR is in reference to an issue which we experienced while integrating marathon-logger with **loggly**. Marathon Logger generates a rsyslog configuration file so as to pass logs to `syslog` which can be consumed by loggly. But the problem here was that length of mesos's tasks log file path in a configuration file for `rsyslog` cannot be more than `200` characters 😢 . 

We fixed this issue by creating a symlink for the absolute path for mesos logs for tasks running on a particular machine. This made our life easy here for deploying marathon-logger for all our mesos-marathon based systems. 

cc : @ashwanthkumar 
