### PR TITLE
Add a hostname check to filter only tasks in the current mesos slave

### DIFF
--- a/app-monitor.go
+++ b/app-monitor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"sync"
 	"time"
 
@@ -75,13 +76,16 @@ func (a *AppMonitor) monitorApps() error {
 				return err
 			}
 			for _, task := range app.Tasks {
-				taskInfo := Task{
-					App:      app.ID,
-					Labels:   *app.Labels,
-					TaskID:   task.ID,
-					Hostname: task.Host,
+				addr, _ := os.Hostname()
+				if task.Host == addr {
+					taskInfo := Task{
+						App:      app.ID,
+						Labels:   *app.Labels,
+						TaskID:   task.ID,
+						Hostname: task.Host,
+					}
+					a.TasksChannel <- taskInfo
 				}
-				a.TasksChannel <- taskInfo
 			}
 		}
 	}


### PR DESCRIPTION
RCA: 

Currently, We're querying the marathon-api to get a list of all the apps (filtered only by logs.enabled=true) 

We're then sending all the tasks of a given app to the tasks channel which will be processed therein. The mesos slave in which the marathon-logger is running, will only have a subset of these tasks and complains about the tasks it doesn't have. 

I've added a check to match hostname of the slave with the Host field of the task. 